### PR TITLE
Mirror of antirez redis#6125

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -29,6 +29,7 @@
 
 #include "server.h"
 #include "cluster.h"
+#define _GNU_SOURCE
 #include <dlfcn.h>
 
 #define REDISMODULE_CORE 1
@@ -5143,7 +5144,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc) {
     void *handle;
     RedisModuleCtx ctx = REDISMODULE_CTX_INIT;
 
-    handle = dlopen(path,RTLD_NOW|RTLD_LOCAL);
+    handle = dlmopen(LM_ID_NEWLM,path,RTLD_NOW|RTLD_LOCAL);
     if (handle == NULL) {
         serverLog(LL_WARNING, "Module %s failed to load: %s", path, dlerror());
         return C_ERR;


### PR DESCRIPTION
Mirror of antirez redis#6125
the dl library calls symbols in redis before its own
isolation of namespaces is necessary for deterministism.
This is useful for instance when embedding own Lua without interfering with Redis.

I suggest to use `dlmopen(3)` on `_GNU_SOURCE` capable systems for complete isolation of runtime symbol namespace resolution.

this very small patch is based on redis 5.0.5

the problem addressed is also debated here https://bugzilla.redhat.com/show_bug.cgi?id=1621927

mainly affects Linux based systems (gnu libc)
