### PR TITLE
Mirror of antirez redis#6129

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1745,6 +1745,17 @@ int clusterProcessPacket(clusterLink *link) {
          * However if we don't have an address at all, we update the address
          * even with a normal PING packet. If it's wrong it will be fixed
          * by MEET later. */
+
+        if (type == CLUSTERMSG_TYPE_MEET) {
+            uint32_t cName =  ntohl(hdr->cName);
+
+            serverLog(LL_DEBUG, "respon check cName :%d %d",cName,server.cName);
+
+            //if (cName != server.cName) {
+            if (cName != server.cName) {
+                return 1;
+            }
+        }
         if ((type == CLUSTERMSG_TYPE_MEET || myself->ip[0] == '\0') &&
             server.cluster_announce_ip == NULL)
         {
@@ -2263,6 +2274,8 @@ void clusterBuildMessageHdr(clusterMsg *hdr, int type) {
     hdr->sig[2] = 'm';
     hdr->sig[3] = 'b';
     hdr->type = htons(type);
+
+    hdr->cName = htonl(server.cName);
     memcpy(hdr->sender,myself->name,CLUSTER_NAMELEN);
 
     /* If cluster-announce-ip option is enabled, force the receivers of our

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -271,6 +271,7 @@ typedef struct {
     uint16_t flags;      /* Sender node flags */
     unsigned char state; /* Cluster state from the POV of the sender */
     unsigned char mflags[3]; /* Message flags: CLUSTERMSG_FLAG[012]_... */
+    uint32_t cName;
     union clusterMsgData data;
 } clusterMsg;
 

--- a/src/config.c
+++ b/src/config.c
@@ -169,6 +169,28 @@ void queueLoadModule(sds path, sds *argv, int argc) {
     listAddNodeTail(server.loadmodule_queue,loadmod);
 }
 
+
+unsigned int APHash(char *str)
+{
+    unsigned int hash = 0;
+    int i;
+ 
+    for (i=0; *str; i++)
+    {
+        if ((i & 1) == 0)
+        {
+            hash ^= ((hash << 7) ^ (*str++) ^ (hash >> 3));
+        }
+        else
+        {
+            hash ^= (~((hash << 11) ^ (*str++) ^ (hash >> 5)));
+        }
+    }
+ 
+    return (hash & 0x7FFFFFFF);
+}
+
+
 void loadServerConfigFromString(char *config) {
     char *err = NULL;
     int linenum = 0, totlines, i;
@@ -833,6 +855,9 @@ void loadServerConfigFromString(char *config) {
                 err = sentinelHandleConfiguration(argv+1,argc-1);
                 if (err) goto loaderr;
             }
+        } else if (!strcasecmp(argv[0],"cluster-name") && argc == 2) {
+            server.cName = APHash(argv[1]);
+            fprintf(stderr,"read cluster name :%d name:%s\n",server.cName,argv[1]);
         } else {
             err = "Bad directive or wrong number of arguments"; goto loaderr;
         }

--- a/src/server.h
+++ b/src/server.h
@@ -1368,6 +1368,7 @@ struct redisServer {
     int watchdog_period;  /* Software watchdog period in ms. 0 = off */
     /* System hardware info */
     size_t system_memory_size;  /* Total memory in system as reported by OS */
+    uint32_t cName;
 };
 
 typedef struct pubsubPattern {


### PR DESCRIPTION
Mirror of antirez redis#6129
Hi:
I face a problem which desc in https://github.com/antirez/redis/issues/2472

It is truly dangerous when a company own many clusters and all ips are visible,because some somebody else may join many redis cluster together intentionally or unintentionally,It may be 
an very serious problem

    So I add a cluster-name testaa in redis.conf, hash the cluster name string into a int flag,
    check the int flag when counter a CLUSTERMSG_TYPE_MEET  message between cluster nodes.

 This problem is desc in https://github.com/antirez/redis/issues/2472 as an proposed-feature feature,
But I really need this feature, could you please take a look at my-code and check as it is right as I am not quite  sure. Thanks very much


