### PR TITLE
Mirror of antirez redis#6164

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -97,11 +97,13 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+
+    if (sh == NULL) return NULL;
+
     if (init==SDS_NOINIT)
         init = NULL;
     else if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {


### PR DESCRIPTION
Mirror of antirez redis#6164
file: sds.c  function: sdsnewline。
Did not check NULL after s_malloc (sh = s_malloc(hdrlen+initlen+1))
