### PR TITLE
Mirror of antirez redis#6189

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -126,6 +126,13 @@ void aeDeleteEventLoop(aeEventLoop *eventLoop) {
     aeApiFree(eventLoop);
     zfree(eventLoop->events);
     zfree(eventLoop->fired);
+    /* Free time event. */
+    aeTimeEvent *next_te, *te = eventLoop->timeEventHead;
+    while (te) {
+        next_te = te->next;
+        zfree(te);
+        te = next_te;
+    }
     zfree(eventLoop);
 }
 


### PR DESCRIPTION
Mirror of antirez redis#6189
free time event when delete event loop to avoid avoid valgrind warning
