### PR TITLE
Mirror of antirez redis#6186

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -97,11 +97,11 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
     if (init==SDS_NOINIT)
         init = NULL;
     else if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {


### PR DESCRIPTION
Mirror of antirez redis#6186
when os memory is not enough, malloc may fail, cause sh set to null,
if init param is null, memset will get null pointer,
that will trigger segment fault exception.

just make the null pointer check earlier, will fix the issue.
