### PR TITLE
Mirror of antirez redis#6243

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -796,7 +796,9 @@ replica-priority 100
 #    or SORT with STORE option may delete existing keys. The SET command
 #    itself removes any old content of the specified key in order to replace
 #    it with the specified string.
-# 4) During replication, when a replica performs a full resynchronization with
+# 4) The DEL command itself, and normally it's not easy to replace DEL with
+#    UNLINK in user's codes.
+# 5) During replication, when a replica performs a full resynchronization with
 #    its master, the content of the whole database is removed in order to
 #    load the RDB file just transferred.
 #
@@ -808,6 +810,7 @@ replica-priority 100
 lazyfree-lazy-eviction no
 lazyfree-lazy-expire no
 lazyfree-lazy-server-del no
+lazyfree-lazy-user-del no
 replica-lazy-flush no
 
 ############################## APPEND ONLY MODE ###############################

--- a/src/config.c
+++ b/src/config.c
@@ -130,6 +130,7 @@ configYesNo configs_yesno[] = {
     {"lazyfree-lazy-eviction",NULL,&server.lazyfree_lazy_eviction,1,CONFIG_DEFAULT_LAZYFREE_LAZY_EVICTION},
     {"lazyfree-lazy-expire",NULL,&server.lazyfree_lazy_expire,1,CONFIG_DEFAULT_LAZYFREE_LAZY_EXPIRE},
     {"lazyfree-lazy-server-del",NULL,&server.lazyfree_lazy_server_del,1,CONFIG_DEFAULT_LAZYFREE_LAZY_SERVER_DEL},
+    {"lazyfree-lazy-user-del",NULL,&server.lazyfree_lazy_user_del,1,CONFIG_DEFAULT_LAZYFREE_LAZY_USER_DEL},
     {"repl-disable-tcp-nodelay",NULL,&server.repl_disable_tcp_nodelay,1,CONFIG_DEFAULT_REPL_DISABLE_TCP_NODELAY},
     {"repl-diskless-sync",NULL,&server.repl_diskless_sync,1,CONFIG_DEFAULT_REPL_DISKLESS_SYNC},
     {"gopher-enabled",NULL,&server.gopher_enabled,1,CONFIG_DEFAULT_GOPHER_ENABLED},

--- a/src/db.c
+++ b/src/db.c
@@ -500,7 +500,7 @@ void delGenericCommand(client *c, int lazy) {
 }
 
 void delCommand(client *c) {
-    delGenericCommand(c,0);
+    delGenericCommand(c,server.lazyfree_lazy_user_del);
 }
 
 void unlinkCommand(client *c) {

--- a/src/server.c
+++ b/src/server.c
@@ -2315,6 +2315,7 @@ void initServerConfig(void) {
     server.lazyfree_lazy_eviction = CONFIG_DEFAULT_LAZYFREE_LAZY_EVICTION;
     server.lazyfree_lazy_expire = CONFIG_DEFAULT_LAZYFREE_LAZY_EXPIRE;
     server.lazyfree_lazy_server_del = CONFIG_DEFAULT_LAZYFREE_LAZY_SERVER_DEL;
+    server.lazyfree_lazy_user_del = CONFIG_DEFAULT_LAZYFREE_LAZY_USER_DEL;
     server.always_show_logo = CONFIG_DEFAULT_ALWAYS_SHOW_LOGO;
     server.lua_time_limit = LUA_SCRIPT_TIME_LIMIT;
     server.io_threads_num = CONFIG_DEFAULT_IO_THREADS_NUM;

--- a/src/server.h
+++ b/src/server.h
@@ -162,6 +162,7 @@ typedef long long mstime_t; /* millisecond time type. */
 #define CONFIG_DEFAULT_LAZYFREE_LAZY_EVICTION 0
 #define CONFIG_DEFAULT_LAZYFREE_LAZY_EXPIRE 0
 #define CONFIG_DEFAULT_LAZYFREE_LAZY_SERVER_DEL 0
+#define CONFIG_DEFAULT_LAZYFREE_LAZY_USER_DEL 0
 #define CONFIG_DEFAULT_ALWAYS_SHOW_LOGO 0
 #define CONFIG_DEFAULT_ACTIVE_DEFRAG 0
 #define CONFIG_DEFAULT_DEFRAG_THRESHOLD_LOWER 10 /* don't defrag when fragmentation is below 10% */
@@ -1385,6 +1386,7 @@ struct redisServer {
     int lazyfree_lazy_eviction;
     int lazyfree_lazy_expire;
     int lazyfree_lazy_server_del;
+    int lazyfree_lazy_user_del;
     /* Latency monitor */
     long long latency_monitor_threshold;
     dict *latency_events;


### PR DESCRIPTION
Mirror of antirez redis#6243
Hi <at>antirez , there are some scenarios that users wanna use lazyfree especially `UNLINK`, but it's difficult to change their project codes, so I think maybe we can expand the effect of `lazyfree-lazy-server-del` to `DEL` command.

BTW, it's unnecessary to add a new configuration IMHO.
