### PR TITLE
Mirror of antirez redis#6329

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1043,18 +1043,18 @@ lua-time-limit 5000
 # the failover if, since the last interaction with the master, the time
 # elapsed is greater than:
 #
-#   (node-timeout * replica-validity-factor) + repl-ping-replica-period
+#   (node-timeout * cluster-replica-validity-factor) + repl-ping-replica-period
 #
-# So for example if node-timeout is 30 seconds, and the replica-validity-factor
+# So for example if node-timeout is 30 seconds, and the cluster-replica-validity-factor
 # is 10, and assuming a default repl-ping-replica-period of 10 seconds, the
 # replica will not try to failover if it was not able to talk with the master
 # for longer than 310 seconds.
 #
-# A large replica-validity-factor may allow replicas with too old data to failover
+# A large cluster-replica-validity-factor may allow replicas with too old data to failover
 # a master, while a too small value may prevent the cluster from being able to
 # elect a replica at all.
 #
-# For maximum availability, it is possible to set the replica-validity-factor
+# For maximum availability, it is possible to set the cluster-replica-validity-factor
 # to a value of 0, which means, that replicas will always try to failover the
 # master regardless of the last time they interacted with the master.
 # (However they'll always try to apply a delay proportional to their


### PR DESCRIPTION
Mirror of antirez redis#6329
In the comments the prop is referenced as replica-validity-factor,
but it is really named cluster-replica-validity-factor.
