### PR TITLE
Mirror of antirez redis#6327

### DIFF
--- a/src/listpack.c
+++ b/src/listpack.c
@@ -666,8 +666,7 @@ unsigned char *lpInsert(unsigned char *lp, unsigned char *ele, uint32_t size, un
     if (where == LP_BEFORE) {
         memmove(dst+enclen+backlen_size,dst,old_listpack_bytes-poff);
     } else { /* LP_REPLACE. */
-        long lendiff = (enclen+backlen_size)-replaced_len;
-        memmove(dst+replaced_len+lendiff,
+        memmove(dst+enclen+backlen_size,
                 dst+replaced_len,
                 old_listpack_bytes-poff-replaced_len);
     }


### PR DESCRIPTION
Mirror of antirez redis#6327
long lendiff = (enclen+backlen_size)-replaced_len
dst+replaced_len+lendiff
= det+replaced_len+(enclen+backlen_size)-replaced_len
= dest+enclen+backlen_size

after this improvement, LP_BEFORE case and LP_REPLACE case is the same
