### PR TITLE
Mirror of antirez redis#6361

### DIFF
--- a/src/siphash.c
+++ b/src/siphash.c
@@ -58,7 +58,8 @@ int siptlw(int c) {
 /* Test of the CPU is Little Endian and supports not aligned accesses.
  * Two interesting conditions to speedup the function that happen to be
  * in most of x86 servers. */
-#if defined(__X86_64__) || defined(__x86_64__) || defined (__i386__)
+#if defined(__X86_64__) || defined(__x86_64__) || defined (__i386__) \
+	|| defined(__aarch64__) || defined(__arm64__)
 #define UNALIGNED_LE_CPU
 #endif
 


### PR DESCRIPTION
Mirror of antirez redis#6361
The aarch64 architecture is support normal memory unaligned access,

so add the UNALIGNED_LE_CPU to the aarch64.

And use the redis-benchmark tested on my arm64 server , everything runs well.

