### PR TITLE
Mirror of antirez redis#6381

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1264,6 +1264,17 @@ int RM_ReplyWithString(RedisModuleCtx *ctx, RedisModuleString *str) {
     return REDISMODULE_OK;
 }
 
+/* Reply to the client with an string representing an OK.
+ * In the RESP protocol a string representing an OK Reply is encoded
+ * as the string "+OK\r\n".
+ * The function always returns REDISMODULE_OK. */
+int RM_ReplyWithOK(RedisModuleCtx *ctx){
+    client *c = moduleGetReplyClient(ctx);
+    if (c == NULL) return REDISMODULE_OK;
+    addReply(c,shared.ok);
+    return REDISMODULE_OK;
+}
+
 /* Reply to the client with a NULL. In the RESP protocol a NULL is encoded
  * as the string "$-1\r\n".
  *
@@ -5389,6 +5400,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ReplySetArrayLength);
     REGISTER_API(ReplyWithString);
     REGISTER_API(ReplyWithStringBuffer);
+    REGISTER_API(ReplyWithOK);
     REGISTER_API(ReplyWithCString);
     REGISTER_API(ReplyWithNull);
     REGISTER_API(ReplyWithCallReply);

--- a/src/modules/testmodule.c
+++ b/src/modules/testmodule.c
@@ -126,6 +126,59 @@ int failTest(RedisModuleCtx *ctx, const char *msg) {
     return REDISMODULE_ERR;
 }
 
+/* TEST.REPLY.WITH.SS.OK -- Test RedisModule_ReplyWithString "OK". */
+int TestReplyWithSimpleStringOK(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* TEST.REPLY.WITH.OK.OK -- Test RedisModule_ReplyWithOK. */
+int TestReplyWithOK(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    return RedisModule_ReplyWithOK(ctx);
+}
+
+/* TEST.SETKEY.REPLY.WITH.SS.OK -- Test Setting a Module Key and Replying with RedisModule_ReplyWithString "OK". */
+int TestSetModuleKeyReplyWithSimpleStringOK(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    RedisModuleString* keystr = RedisModule_CreateStringFromString(ctx,argv[1]);
+    RedisModuleString* valuesstr = RedisModule_CreateStringFromString(ctx,argv[2]);
+    RedisModuleKey *k = RedisModule_OpenKey(ctx, keystr, REDISMODULE_WRITE);
+    if (!k) return failTest(ctx, "Could not create key");
+    if (REDISMODULE_ERR == RedisModule_StringSet(k,valuesstr) ) {
+        return failTest(ctx, "Could not set string value");
+    }
+    RedisModule_CloseKey(k);
+    RedisModule_ReplicateVerbatim(ctx);
+
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+
+}
+
+/* TEST.SETKEY.REPLY.WITH.OK.OK -- Test Setting a Module Key and Replying with RedisModule_ReplyWithOK "OK". */
+int TestSetModuleKeyReplyWithOK(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    RedisModuleString* keystr = RedisModule_CreateStringFromString(ctx,argv[1]);
+    RedisModuleString* valuesstr = RedisModule_CreateStringFromString(ctx,argv[2]);
+    RedisModuleKey *k = RedisModule_OpenKey(ctx, keystr, REDISMODULE_WRITE);
+    if (!k) return failTest(ctx, "Could not create key");
+    if (REDISMODULE_ERR == RedisModule_StringSet(k,valuesstr) ) {
+        return failTest(ctx, "Could not set string value");
+    }
+    RedisModule_CloseKey(k);
+    RedisModule_ReplicateVerbatim(ctx);
+
+    return RedisModule_ReplyWithOK(ctx);
+}
+
 int TestUnlink(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
     REDISMODULE_NOT_USED(argv);
@@ -432,6 +485,22 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     if (RedisModule_CreateCommand(ctx,"test.string.printf",
         TestStringPrintf,"write deny-oom",1,1,1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+    
+    if (RedisModule_CreateCommand(ctx,"test.reply.with.ss.ok",
+        TestReplyWithSimpleStringOK,"readonly",1,1,1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"test.reply.with.ok.ok",
+        TestReplyWithOK,"readonly",1,1,1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"test.set.reply.with.ss.ok",
+        TestSetModuleKeyReplyWithSimpleStringOK,"write deny-oom",1,1,1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"test.set.reply.with.ok.ok",
+        TestSetModuleKeyReplyWithOK,"write deny-oom",1,1,1) == REDISMODULE_ERR)
         return REDISMODULE_ERR;
 
     if (RedisModule_CreateCommand(ctx,"test.ctxflags",

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -239,6 +239,7 @@ void REDISMODULE_API_FUNC(RedisModule_ReplySetArrayLength)(RedisModuleCtx *ctx, 
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithStringBuffer)(RedisModuleCtx *ctx, const char *buf, size_t len);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithCString)(RedisModuleCtx *ctx, const char *buf);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithString)(RedisModuleCtx *ctx, RedisModuleString *str);
+int REDISMODULE_API_FUNC(RedisModule_ReplyWithOK)(RedisModuleCtx *ctx);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithNull)(RedisModuleCtx *ctx);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithDouble)(RedisModuleCtx *ctx, double d);
 int REDISMODULE_API_FUNC(RedisModule_ReplyWithCallReply)(RedisModuleCtx *ctx, RedisModuleCallReply *reply);
@@ -390,6 +391,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ReplyWithStringBuffer);
     REDISMODULE_GET_API(ReplyWithCString);
     REDISMODULE_GET_API(ReplyWithString);
+    REDISMODULE_GET_API(ReplyWithOK);
     REDISMODULE_GET_API(ReplyWithNull);
     REDISMODULE_GET_API(ReplyWithCallReply);
     REDISMODULE_GET_API(ReplyWithDouble);


### PR DESCRIPTION
Mirror of antirez redis#6381
This PR focus on reusing redis shared common object `shared.ok` to create a RedisModule_ReplyWithOK method, with the main goal to reduce memory allocation/deallocation during runtime, when compared to using RedisModule_ReplyWithSimpleString(ctx, "OK").
Even tough "OK" is a simple and short string "+OK\r\n" ( 5 Bytes on RESP ), constantly issuing zmalloc/zfree has penalties in terms of performance. The more objects and memory we have to manage the more RedisModule_ReplyWithOK will perfom vs RedisModule_ReplyWithSimpleString. 
This is a small code change wich implies:

- [add] added RM_ReplyWithOK method that makes use of redis shared common objects to reduce memory allocation during runtime.
- [add] added tests for RM_ReplyWithOK vs ReplyWithSimpleStringOK to the testsuit of Redis modules subsystem.

-------
## Benchmarks using memtier and output of commandstats, call history analysis using callgrind
### Quick note
The benchmark values and call history analysis using callgrind presented bellow used Redis version=5.0.5, bits=64, commit=c696aebd, and were retrived on a local machine ( Intel(R) Core(TM) i7-9750H CPU <at> 2.60GHz ) with OS Darwin 18.7.0 x86_64. Considering that both the client and DB Server were on the same physical machine it is advised to run the same tests on a production graded DB machine with separate clients issuing the load. Despite that, all benchmark values ( even if local ) and call history among functions revelead steady state runs and results ( It all points towards performance improvements =) ).

Across tests, Redis OSS v5.0.5 was started always with:
```
redis-server --protected-mode no --save "" --appendonly no  --loadmodule src/modules/testmodule.so
```
when doing the call history analysis, callgrind was started in the following manner:
```
valgrind  --tool=callgrind --dump-instr=yes --simulate-cache=no --collect-jumps=yes --collect-atstart=yes --instr-atstart=yes redis-server --protected-mode no --save "" --appendonly no  --loadmodule src/modules/testmodule.so
```
## 1)Benchmarks
To test the meaningfullness of this PR we've added 4 commands to the testsuit of Redis modules subsystem: 
 - 1)Two that only reply with with "+OK\r\n", with the purpose of isolating and testing only RedisModule_ReplyWithOK. 
-  2)Two that set a new key to redis and reply with "+OK\r\n", with the purpose of testing the positive impact of RedisModule_ReplyWithOK to commands that modify the dataset. 

### 1.1) Simple commands that only reply with "+OK\r\n"
- `TEST.REPLY.WITH.SS.OK` - which does nothing more than replying with RedisModule_ReplyWithSimpleString(ctx, "OK").
- `TEST.REPLY.WITH.OK.OK`- which does nothing more than replying with RedisModule_ReplyWithOK(ctx).

memtier used commands:
```
memtier_benchmark -n 20000 -c 50 -t 1 --command="TEST.REPLY.WITH.SS.OK" --hide-histogram
memtier_benchmark -n 20000 -c 50 -t 1 --command="TEST.REPLY.WITH.OK.OK" --hide-histogram
```

### 1.1.1)Memtier output for simple tests
Type | Ops/sec | Latency | KB/sec | # Connections | Total Commands
-- | -- | -- | -- | -- | --
RedisModule_ReplyWithSimpleString(ctx, "OK") | 111560.36 | 0.447 | 4030.99 | 50 | 1M
RedisModule_ReplyWithOK(ctx) | 112980.73 | 0.441 | 4082.31 | 50 | 1M


### 1.1.2)Redis command statistics output 
```
# Commandstats
cmdstat_test.reply.with.ok.ok:calls=1000000,usec=165097,usec_per_call=0.17
cmdstat_test.reply.with.ss.ok:calls=1000000,usec=492430,usec_per_call=0.49
```
### 1.1.3)simple commands conclusions
From the client prespective no major variation was observed, *however*, as seen from the Redis command statistics, **on average the command that returned the response via RedisModule_ReplyWithOK took  0.17 us, vs 0.49 us for RedisModule_ReplyWithSimpleString(ctx, "OK")**.

----

### 1.2)Testing the positive impact of RedisModule_ReplyWithOK to commands that modify the dataset 
- `TEST.SETKEY.REPLY.WITH.SS.OK` - which tests setting a Module Key and Replying with RedisModule_ReplyWithSimpleString(ctx, "OK").
- `TEST.SETKEY.REPLY.WITH.OK.OK`- which tests setting a Module Key and Replying with RedisModule_ReplyWithOK(ctx).

memtier used commands:
```
##############
# 50 Connections
##############

##############
# RedisModule_ReplyWithSimpleString
##############
memtier_benchmark -n 100000 -c 50 -t 1  --command="TEST.SET.REPLY.WITH.SS.OK __key__ __data__" --command-key-patter=P --data-size=128 --hide-histogram
memtier_benchmark -n 40000 -c 50 -t 1  --command="TEST.SET.REPLY.WITH.SS.OK __key__ __data__" --command-key-patter=P --data-size=1024 --hide-histogram
memtier_benchmark -n 40000 -c 50 -t 1  --command="TEST.SET.REPLY.WITH.SS.OK __key__ __data__" --command-key-patter=P --data-size=8192 --hide-histogram

##############
# RedisModule_ReplyWithOK
##############
memtier_benchmark -n 100000 -c 50 -t 1  --command="TEST.SET.REPLY.WITH.OK.OK __key__ __data__" --command-key-patter=P --data-size=128 --hide-histogram
memtier_benchmark -n 100000 -c 50 -t 1  --command="TEST.SET.REPLY.WITH.OK.OK __key__ __data__" --command-key-patter=P --data-size=1024 --hide-histogram
memtier_benchmark -n 100000 -c 50 -t 1  --command="TEST.SET.REPLY.WITH.OK.OK __key__ __data__" --command-key-patter=P --data-size=8192 --hide-histogram

##############
# 200 Connections
##############

##############
# RedisModule_ReplyWithSimpleString
##############
memtier_benchmark -n 100000 -c 200 -t 1  --command="TEST.SET.REPLY.WITH.SS.OK __key__ __data__" --command-key-patter=P --data-size=128 --hide-histogram
memtier_benchmark -n 100000 -c 200 -t 1  --command="TEST.SET.REPLY.WITH.SS.OK __key__ __data__" --command-key-patter=P --data-size=1024 --hide-histogram
memtier_benchmark -n 100000 -c 200 -t 1  --command="TEST.SET.REPLY.WITH.SS.OK __key__ __data__" --command-key-patter=P --data-size=8192 --hide-histogram

##############
# RedisModule_ReplyWithOK
##############
memtier_benchmark -n 100000 -c 200 -t 1  --command="TEST.SET.REPLY.WITH.OK.OK __key__ __data__" --command-key-patter=P --data-size=128 --hide-histogram
memtier_benchmark -n 100000 -c 200 -t 1  --command="TEST.SET.REPLY.WITH.OK.OK __key__ __data__" --command-key-patter=P --data-size=1024 --hide-histogram
memtier_benchmark -n 100000 -c 200 -t 1  --command="TEST.SET.REPLY.WITH.OK.OK __key__ __data__" --command-key-patter=P --data-size=8192 --hide-histogram

```

### 1.2.1)Memtier output for tests that incorporate commands that modify the dataset

Reply Type | Data size | ops/sec | Latency | KB/sec | # Connections | Total Commands
-- | -- | -- | -- | -- | -- | --
RedisModule_ReplyWithSimpleString(ctx, "OK") | 128 | 104870.66 | 1.906 | 20368.65 | 200 | 5M
RedisModule_ReplyWithSimpleString(ctx, "OK") | 1024 | 98749.05 | 2.024 | 105681.52 | 200 | 5M
RedisModule_ReplyWithSimpleString(ctx, "OK") | 8192 | 67341.87 | 2.968 | 543462.56 | 200 | 5M
RedisModule_ReplyWithOK(ctx) | 128 | 103915.41 | 1.924 | 20183.11 | 200 | 5M
RedisModule_ReplyWithOK(ctx) | 1024 | 96303.62 | 2.076 | 103064.41 | 200 | 5M
RedisModule_ReplyWithOK(ctx) | 8192 | 71607.21 | 2.807 | 577884.72 | 200 | 5M


![image](https://user-images.githubusercontent.com/5832149/64791347-7f93f580-d56f-11e9-80d8-9756619960bf.png)


### 1.2.2)Redis command statistics output 
```
# Commandstats
(200clients/128B) cmdstat_test.set.reply.with.ss.ok:calls=5000000,usec=11518708,usec_per_call=2.30
(200clients/1024B) cmdstat_test.set.reply.with.ss.ok:calls=5000000,usec=14593663,usec_per_call=2.92
(200clients/8192B) cmdstat_test.set.reply.with.ss.ok:calls=5000000,usec=33258066,usec_per_call=6.65
(200clients/128B) cmdstat_test.set.reply.with.ok.ok:calls=5000000,usec=9615639,usec_per_call=1.92
(200clients/1024B) cmdstat_test.set.reply.with.ok.ok:calls=5000000,usec=12931561,usec_per_call=2.59
(200clients/8192B) cmdstat_test.set.reply.with.ok.ok:calls=5000000,usec=30069395,usec_per_call=6.01
```

![image](https://user-images.githubusercontent.com/5832149/64793093-68a2d280-d572-11e9-84b7-95a8b71519ab.png)


### 1.2.3)simple commands conclusions
From the client, we can observe performance improvements on RedisModule_ReplyWithOK for the largest data size and the largest number of clients.
From the Redis command statistics, ** for all key sizes and client variations RedisModule_ReplyWithOK(ctx) performed significantly better than RedisModule_ReplyWithSimpleString(ctx, "OK")**.

--------------
## 2)Call history analysis using callgrind
When doing the call history analysis, callgrind was started in the following manner:
```
valgrind  --tool=callgrind --dump-instr=yes --simulate-cache=no --collect-jumps=yes --collect-atstart=yes --instr-atstart=yes redis-server --protected-mode no --save "" --appendonly no  --loadmodule src/modules/testmodule.so
```
The output of the two benchmarks ( 1M commands each ) is sent as attachment. 
[callgrind.out.RedisModule_ReplyWithSimpleStringOKvsRedisModule_ReplyWithOK.zip](https://github.com/antirez/redis/files/3606028/callgrind.out.RedisModule_ReplyWithSimpleStringOKvsRedisModule_ReplyWithOK.zip)

### Call History summary report 
As seen on the following callgraph sections ( 2.1 and 2.2 ) RedisModule_ReplyWithSimpleString(ctx, "OK") represents 32.61% of the total Cycles spent on the command method, vs 8.38% of RedisModule_ReplyWithOK(ctx). 

You can observe that RedisModule_ReplyWithSimpleString(ctx, "OK") makes more memory management function calls ( zmalloc zrealloc zfree ) spending 48.42 + 9.65 + 16.58 = 74.55% of the total cycles spent on the command ( Using the Redis command statistics output 
 from RedisModule_ReplyWithOK(ctx) it represents 74.55% * 11518708 us = 8,587,196.814 us ). Compared to the command which issues RedisModule_ReplyWithOK(ctx) that spends 52.51 + 13.10 + 6.14 = 71.75% * 9615639 us = 6,899,220.9825 us it represents a difference of 20% less time spend on zmalloc zrealloc zfree. 



### 2.1)Call history analysis using callgrind for RedisModule_ReplyWithSimpleString(ctx, "OK")

![image](https://user-images.githubusercontent.com/5832149/64793802-83297b80-d573-11e9-8c84-2de67a525939.png)



### 2.2)Call history analysis using callgrind for RedisModule_ReplyWithOK(ctx)


![image](https://user-images.githubusercontent.com/5832149/64793783-7dcc3100-d573-11e9-8b9d-f7c5a6efef14.png)






