### PR TITLE
Mirror of antirez redis#6775

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3498,7 +3498,10 @@ int processCommand(client *c) {
         c->cmd->proc != unsubscribeCommand &&
         c->cmd->proc != psubscribeCommand &&
         c->cmd->proc != punsubscribeCommand) {
-        addReplyError(c,"only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context");
+        addReplyErrorFormat(c,
+            "'%s' command submitted, but only (P)SUBSCRIBE / "
+            "(P)UNSUBSCRIBE / PING / QUIT allowed in this context",
+            c->cmd->name);
         return C_OK;
     }
 


### PR DESCRIPTION
Mirror of antirez redis#6775
Adding useful details for an error message when client submitting command in context, that only limited scope of commands.

An opened issue: https://github.com/antirez/redis/issues/6770

Error message
`ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context`
will become
`ERR 'get' command submitted, but only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context`
