### PR TITLE
Mirror of antirez redis#6815

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -538,6 +538,10 @@ NULL
         if (c->argc == 5)
             if (getLongFromObjectOrReply(c, c->argv[4], &valsize, NULL) != C_OK)
                 return;
+        if (valsize < 0) {
+            addReplyError(c,"The value size argument must be >= 0");
+            return;
+        }
         dictExpand(c->db->dict,keys);
         for (j = 0; j < keys; j++) {
             snprintf(buf,sizeof(buf),"%s:%lu",

--- a/src/debug.c
+++ b/src/debug.c
@@ -529,21 +529,20 @@ NULL
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"populate") &&
                c->argc >= 3 && c->argc <= 5) {
-        long keys, j;
+        long keys, j, valsize = 0;
         robj *key, *val;
         char buf[128];
 
         if (getLongFromObjectOrReply(c, c->argv[2], &keys, NULL) != C_OK)
             return;
+        if (c->argc == 5)
+            if (getLongFromObjectOrReply(c, c->argv[4], &valsize, NULL) != C_OK)
+                return;
         dictExpand(c->db->dict,keys);
         for (j = 0; j < keys; j++) {
-            long valsize = 0;
             snprintf(buf,sizeof(buf),"%s:%lu",
                 (c->argc == 3) ? "key" : (char*)c->argv[3]->ptr, j);
             key = createStringObject(buf,strlen(buf));
-            if (c->argc == 5)
-                if (getLongFromObjectOrReply(c, c->argv[4], &valsize, NULL) != C_OK)
-                    return;
             if (lookupKeyWrite(c->db,key) != NULL) {
                 decrRefCount(key);
                 continue;


### PR DESCRIPTION
Mirror of antirez redis#6815
crash occurs when negative value is passed for value size:

./redis-cli debug populate 1 prefix -1

memory leak occurs when a non-numeric arg is passed

reproduce leak with:

./redis-cli -r 10000 debug populate 10 prefix badarg > /dev/null
