### PR TITLE
Mirror of antirez redis#6886

### DIFF
--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -179,7 +179,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <mach/memory_object_types.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Mirror of antirez redis#6886
Dear sir:
Current implementation of __ziplistCascadeUpdate is of O(n^2) time complexity. I try to optimize it with an algorithm of O(n) time complexity.
Here is the basic idea: 
1. loop ziplist to find how many extra bytes need to update the whole list
2. resize ziplist once and do update job from back to front

This PR has passed make test.
