### PR TITLE
Mirror of redis redis#7554

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -60,7 +60,6 @@ proc spawn_instance {type base_port count {conf {}}} {
     for {set j 0} {$j < $count} {incr j} {
         set port [find_available_port $base_port $::redis_port_count]
         incr base_port
-        puts "Starting $type #$j at port $port"
 
         # Create a directory for this instance.
         set dirname "${type}_${j}"
@@ -93,10 +92,30 @@ proc spawn_instance {type base_port count {conf {}}} {
         close $cfg
 
         # Finally exec it and remember the pid for later cleanup.
-        set pid [exec_instance $type $cfgfile]
-        lappend ::pids $pid
+        set retry 100
+        while {$retry} {
+            set pid [exec_instance $type $cfgfile]
 
-        # Check availability
+            # Check availability
+            if {[server_is_up 127.0.0.1 $port 100] == 0} {
+                puts "Starting $type #$j at port $port failed, try another"
+                incr retry -1
+                set port [find_available_port $base_port $::redis_port_count]
+                incr base_port
+                set cfg [open $cfgfile a+]
+                puts $cfg "port $port"
+                if {$::tls} {
+                    puts $cfg "tls-port $port"
+                }
+                close $cfg
+            } else {
+                puts "Starting $type #$j at port $port"
+                lappend ::pids $pid
+                break
+            }  
+        }
+
+        # Check availability finally
         if {[server_is_up 127.0.0.1 $port 100] == 0} {
             abort_sentinel_test "Problems starting $type #$j: ping timeout"
         }


### PR DESCRIPTION
Mirror of redis redis#7554
When runtest-cluster, at first, we need to create a cluster use spawn_instance, a port which is not used is choosen, however we can't run server on the port. such as https://github.com/redis/redis/runs/896537490. It may be due to the machine problem or another process take up the port at once. As a result, runtest-cluster failed. In order to reduce the probability of failure when start redis in runtest-cluster, we attemp to use another port when find server do not start up.
