### PR TITLE
Mirror of redis redis PR IssueNumber 8429

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -964,6 +964,11 @@ void hscanCommand(client *c) {
  * implementation for more info. */
 #define HRANDFIELD_SUB_STRATEGY_MUL 3
 
+/* If client is trying to ask for a very large number of random elements,
+ * queuing may consume an unlimited amount of memory, so we want to limit
+ * number of randoms per time. */
+#define HRANDFIELD_RANDOM_SAMPLE_LIMIT 1000
+
 void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     unsigned long count, size;
     int uniq = 1;
@@ -992,7 +997,6 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
      * structures. This case is the only one that also needs to return the
      * elements in random order. */
     if (!uniq || count == 1) {
-        count = count > size ? size : count;
         if (withvalues && c->resp == 2)
             addReplyArrayLen(c, count*2);
         else
@@ -1011,22 +1015,28 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
             }
         } else if (hash->encoding == OBJ_ENCODING_ZIPLIST) {
             ziplistEntry *keys, *vals = NULL;
-            keys = zmalloc(sizeof(ziplistEntry)*count);
+            unsigned long limit, sample_count;
+            limit = count > HRANDFIELD_RANDOM_SAMPLE_LIMIT ? HRANDFIELD_RANDOM_SAMPLE_LIMIT : count;
+            keys = zmalloc(sizeof(ziplistEntry)*limit);
             if (withvalues)
-                vals = zmalloc(sizeof(ziplistEntry)*count);
-            ziplistRandomPairs(hash->ptr, count, keys, vals);
-            for (unsigned long i = 0; i < count; i++) {
-                if (withvalues && c->resp > 2)
-                    addReplyArrayLen(c,2);
-                if (keys[i].sval)
-                    addReplyBulkCBuffer(c, keys[i].sval, keys[i].slen);
-                else
-                    addReplyBulkLongLong(c, keys[i].lval);
-                if (withvalues) {
-                    if (vals[i].sval)
-                        addReplyBulkCBuffer(c, vals[i].sval, vals[i].slen);
+                vals = zmalloc(sizeof(ziplistEntry)*limit);
+            while (count) {
+                sample_count = count > limit ? limit : count;
+                count -= sample_count;
+                ziplistRandomPairs(hash->ptr, sample_count, keys, vals);
+                for (unsigned long i = 0; i < sample_count; i++) {
+                    if (withvalues && c->resp > 2)
+                        addReplyArrayLen(c,2);
+                    if (keys[i].sval)
+                        addReplyBulkCBuffer(c, keys[i].sval, keys[i].slen);
                     else
-                        addReplyBulkLongLong(c, vals[i].lval);
+                        addReplyBulkLongLong(c, keys[i].lval);
+                    if (withvalues) {
+                        if (vals[i].sval)
+                            addReplyBulkCBuffer(c, vals[i].sval, vals[i].slen);
+                        else
+                            addReplyBulkLongLong(c, vals[i].lval);
+                    }
                 }
             }
             zfree(keys);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -992,6 +992,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
      * structures. This case is the only one that also needs to return the
      * elements in random order. */
     if (!uniq || count == 1) {
+        count = count > size ? size : count;
         if (withvalues && c->resp == 2)
             addReplyArrayLen(c, count*2);
         else

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3989,6 +3989,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
      * structures. This case is the only one that also needs to return the
      * elements in random order. */
     if (!uniq || count == 1) {
+        count = count > size ? size : count;
         if (withscores && c->resp == 2)
             addReplyArrayLen(c, count*2);
         else

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3961,6 +3961,11 @@ void bzpopmaxCommand(client *c) {
  * implementation for more info. */
 #define ZRANDMEMBER_SUB_STRATEGY_MUL 3
 
+/* If client is trying to ask for a very large number of random elements,
+ * queuing may consume an unlimited amount of memory, so we want to limit
+ * number of randoms per time. */
+#define ZRANDMEMBER_RANDOM_SAMPLE_LIMIT 1000
+
 void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     unsigned long count, size;
     int uniq = 1;
@@ -3989,7 +3994,6 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
      * structures. This case is the only one that also needs to return the
      * elements in random order. */
     if (!uniq || count == 1) {
-        count = count > size ? size : count;
         if (withscores && c->resp == 2)
             addReplyArrayLen(c, count*2);
         else
@@ -4007,22 +4011,28 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
             }
         } else if (zsetobj->encoding == OBJ_ENCODING_ZIPLIST) {
             ziplistEntry *keys, *vals = NULL;
-            keys = zmalloc(sizeof(ziplistEntry)*count);
+            unsigned long limit, sample_count;
+            limit = count > ZRANDMEMBER_RANDOM_SAMPLE_LIMIT ? ZRANDMEMBER_RANDOM_SAMPLE_LIMIT : count;
+            keys = zmalloc(sizeof(ziplistEntry)*limit);
             if (withscores)
-                vals = zmalloc(sizeof(ziplistEntry)*count);
-            ziplistRandomPairs(zsetobj->ptr, count, keys, vals);
-            for (unsigned long i = 0; i < count; i++) {
-                if (withscores && c->resp > 2)
-                    addReplyArrayLen(c,2);
-                if (keys[i].sval)
-                    addReplyBulkCBuffer(c, keys[i].sval, keys[i].slen);
-                else
-                    addReplyBulkLongLong(c, keys[i].lval);
-                if (withscores) {
-                    if (vals[i].sval) {
-                        addReplyDouble(c, zzlStrtod(vals[i].sval,vals[i].slen));
-                    } else
-                        addReplyDouble(c, vals[i].lval);
+                vals = zmalloc(sizeof(ziplistEntry)*limit);
+            while (count) {
+                sample_count = count > limit ? limit : count;
+                count -= sample_count;
+                ziplistRandomPairs(zsetobj->ptr, sample_count, keys, vals);
+                for (unsigned long i = 0; i < sample_count; i++) {
+                    if (withscores && c->resp > 2)
+                        addReplyArrayLen(c,2);
+                    if (keys[i].sval)
+                        addReplyBulkCBuffer(c, keys[i].sval, keys[i].slen);
+                    else
+                        addReplyBulkLongLong(c, keys[i].lval);
+                    if (withscores) {
+                        if (vals[i].sval) {
+                            addReplyDouble(c, zzlStrtod(vals[i].sval,vals[i].slen));
+                        } else
+                            addReplyDouble(c, vals[i].lval);
+                    }
                 }
             }
             zfree(keys);

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1542,7 +1542,7 @@ void ziplistRandomPairs(unsigned char *zl, int count, ziplistEntry *keys, ziplis
     unsigned int klen, vlen;
     long long klval, vlval;
 
-    /* Avoid modify the position of the index in the struct. */
+    /* Notice: the index member must be first due to the use in intCompare */
     typedef struct {
         int index;
         int order;

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1529,8 +1529,8 @@ typedef struct {
 
 /* rand_pick compare by index for qsort */
 int randPickCompareByIndex(const void *a, const void *b) {
-    rand_pick *rp1 = (rand_pick *)a;
-    rand_pick *rp2 = (rand_pick *)b;
+    const rand_pick *rp1 = a;
+    const rand_pick *rp2 = b;
     return rp1->index - rp2->index;
 }
 

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1522,16 +1522,9 @@ void ziplistRandomPair(unsigned char *zl, unsigned long total_count, ziplistEntr
     assert(ret != 0);
 }
 
-typedef struct {
-    int index;
-    int order;
-} rand_pick;
-
-/* rand_pick compare by index for qsort */
-int randPickCompareByIndex(const void *a, const void *b) {
-    rand_pick *rp1 = (rand_pick *)a;
-    rand_pick *rp2 = (rand_pick *)b;
-    return rp1->index - rp2->index;
+/* int compare for qsort */
+int intCompare(const void *a, const void *b) {
+    return (*(int *) a - *(int *) b);
 }
 
 /* Helper method to store a string into from val or lval into dest */
@@ -1548,7 +1541,10 @@ void ziplistRandomPairs(unsigned char *zl, int count, ziplistEntry *keys, ziplis
     unsigned char *p, *key, *value;
     unsigned int klen, vlen;
     long long klval, vlval;
-    
+    typedef struct {
+        int index;
+        int order;
+    } rand_pick;
     rand_pick *picks = zmalloc(sizeof(rand_pick)*count);
     unsigned long total_size = ziplistLen(zl)/2;
 
@@ -1563,7 +1559,7 @@ void ziplistRandomPairs(unsigned char *zl, int count, ziplistEntry *keys, ziplis
     }
 
     /* sort by indexes. */
-    qsort(picks, count, sizeof(rand_pick), randPickCompareByIndex);
+    qsort(picks, count, sizeof(rand_pick), intCompare);
 
     /* fetch the elements form the ziplist into a output array respecting the original order. */
     int zipindex = 0, pickindex = 0;

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1529,8 +1529,8 @@ typedef struct {
 
 /* rand_pick compare by index for qsort */
 int randPickCompareByIndex(const void *a, const void *b) {
-    const rand_pick *rp1 = a;
-    const rand_pick *rp2 = b;
+    rand_pick *rp1 = (rand_pick *)a;
+    rand_pick *rp2 = (rand_pick *)b;
     return rp1->index - rp2->index;
 }
 

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1522,9 +1522,16 @@ void ziplistRandomPair(unsigned char *zl, unsigned long total_count, ziplistEntr
     assert(ret != 0);
 }
 
-/* int compare for qsort */
-int intCompare(const void *a, const void *b) {
-    return (*(int *) a - *(int *) b);
+typedef struct {
+    int index;
+    int order;
+} rand_pick;
+
+/* rand_pick compare by index for qsort */
+int randPickCompareByIndex(const void *a, const void *b) {
+    rand_pick *rp1 = (rand_pick *)a;
+    rand_pick *rp2 = (rand_pick *)b;
+    return rp1->index - rp2->index;
 }
 
 /* Helper method to store a string into from val or lval into dest */
@@ -1541,10 +1548,7 @@ void ziplistRandomPairs(unsigned char *zl, int count, ziplistEntry *keys, ziplis
     unsigned char *p, *key, *value;
     unsigned int klen, vlen;
     long long klval, vlval;
-    typedef struct {
-        int index;
-        int order;
-    } rand_pick;
+    
     rand_pick *picks = zmalloc(sizeof(rand_pick)*count);
     unsigned long total_size = ziplistLen(zl)/2;
 
@@ -1559,7 +1563,7 @@ void ziplistRandomPairs(unsigned char *zl, int count, ziplistEntry *keys, ziplis
     }
 
     /* sort by indexes. */
-    qsort(picks, count, sizeof(rand_pick), intCompare);
+    qsort(picks, count, sizeof(rand_pick), randPickCompareByIndex);
 
     /* fetch the elements form the ziplist into a output array respecting the original order. */
     int zipindex = 0, pickindex = 0;

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1541,6 +1541,8 @@ void ziplistRandomPairs(unsigned char *zl, int count, ziplistEntry *keys, ziplis
     unsigned char *p, *key, *value;
     unsigned int klen, vlen;
     long long klval, vlval;
+
+    /* Avoid modify the position of the index in the struct. */
     typedef struct {
         int index;
         int order;

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -96,9 +96,13 @@ start_server {tags {"hash"}} {
             # 1) Check that it returns repeated elements with and without values.
             set res [r hrandfield myhash -20]
             assert_equal [llength $res] 20
+            set res [r hrandfield myhash -1001]
+            assert_equal [llength $res] 1001
             # again with WITHVALUES
             set res [r hrandfield myhash -20 withvalues]
             assert_equal [llength $res] 40
+            set res [r hrandfield myhash -1001 withvalues]
+            assert_equal [llength $res] 2002
 
             # 2) Check that all the elements actually belong to the original hash.
             foreach {key val} $res {

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1646,9 +1646,13 @@ start_server {tags {"zset"}} {
             # 1) Check that it returns repeated elements with and without values.
             set res [r zrandmember myzset -20]
             assert_equal [llength $res] 20
+            set res [r zrandmember myzset -1001]
+            assert_equal [llength $res] 1001
             # again with WITHSCORES
             set res [r zrandmember myzset -20 withscores]
             assert_equal [llength $res] 40
+            set res [r zrandmember myzset -1001 withscores]
+            assert_equal [llength $res] 2002
 
             # 2) Check that all the elements actually belong to the original zset.
             foreach {key val} $res {


### PR DESCRIPTION
Mirror of redis redis PR IssueNumber 8429
This is not a bug, because intCompare is converted to int* and gets exactly the value of index, but this behavior should be very dangerous.
