### PR TITLE
Mirror of redis redis PR IssueNumber 8436

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -3471,7 +3471,7 @@ NULL
     key = c->argv[2];
 
     /* Lookup the key now, this is common for all the subcommands but HELP. */
-    robj *o = lookupKeyWriteOrReply(c,key,shared.nokeyerr);
+    robj *o = lookupKeyReadOrReply(c,key,shared.nokeyerr);
     if (o == NULL || checkType(c,o,OBJ_STREAM)) return;
     s = o->ptr;
 


### PR DESCRIPTION
Mirror of redis redis PR IssueNumber 8436
now we support client pause write, in case of read command read stale data during write pausing.

COPY is a write command, but the source key is just read.
